### PR TITLE
Fix failure to build

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "eject": "react-scripts eject",
     "report-coverage": "npm test -- --coverage --watchAll=false && codecov"
   },
-  "proxy": "http://localhost:3001", 
+  "proxy": "http://localhost:3001",
   "eslintConfig": {
     "extends": "react-app"
   },
@@ -34,5 +34,3 @@
     ]
   }
 }
-
-

--- a/client/src/components/App/App.css
+++ b/client/src/components/App/App.css
@@ -1,19 +1,5 @@
-.App {
+.app {
   text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
   background-color: #282c34;
   min-height: 100vh;
   display: flex;
@@ -22,17 +8,4 @@
   justify-content: center;
   font-size: calc(10px + 2vmin);
   color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
 }

--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -1,24 +1,10 @@
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div className="app">
+      <p> This is our app. </p>
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node index.js",
     "heroku-postbuild": "cd client && npm i && npm run build",
     "dev-build": "cd client && npm run build && cd .. && node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "react-test": "cd client && npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
strip App files of React template
add react-test script to root package.json to run tests from client folder (i.e. in React environment)